### PR TITLE
added import CoreImage to VisionNative.swift to get rid of error

### DIFF
--- a/UnityVision-iOS/Assets/Scripts/Possible/Vision/Plugins/iOS/VisionNative.swift
+++ b/UnityVision-iOS/Assets/Scripts/Possible/Vision/Plugins/iOS/VisionNative.swift
@@ -8,6 +8,7 @@
 import Foundation
 import AVFoundation
 import Vision
+import CoreImage
 
 @objc public class VisionNative: NSObject {
     


### PR DESCRIPTION
I opened up the project after not using it for a while and I was getting an `Error: “use of unresolved identifier”` for CIImage error on the VisionNative.swift script on line 93 
`        // Create an image from the current state of the buffer
        guard let image = CIImage(mtlTexture: texture, options: nil) else { return false }`

my xcode is Version 11.0 (11A420a)

adding a simple import CoreImage to the top fixed my error. I really don't know why this error happened...